### PR TITLE
Update Cluster Agent release version to v1.0.28

### DIFF
--- a/deploy/helm/chkk-cluster-agent/Chart.yaml
+++ b/deploy/helm/chkk-cluster-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: chkk-cluster-agent
 description: Chkk cluster agent Helm chart
-version: v1.0.27
-appVersion: v1.0.27
+version: v1.0.28
+appVersion: v1.0.28

--- a/deploy/helm/chkk-cluster-agent/values.yaml
+++ b/deploy/helm/chkk-cluster-agent/values.yaml
@@ -4,13 +4,13 @@
 
 image:
   repository: public.ecr.aws/j8z4q9j4/chkk-kontext
-  tag: v1.0.27
+  tag: v1.0.28
   pullPolicy: IfNotPresent
 
 manager:
   image:
     repository: public.ecr.aws/j8z4q9j4/chkk-cluster-agent-manager
-    tag: v1.0.27
+    tag: v1.0.28
     pullPolicy: IfNotPresent
   resources:
     limits:
@@ -35,7 +35,7 @@ config:
           match: ^DaemonSet|Deployment|Pod|PodTemplate|ReplicationController|StatefulSet$
       - include:
         - path: $.kind
-          match: ^NetworkPolicy|CronJob|Namespace|Service|Job|Ingress$
+          match: ^NetworkPolicy|CronJob|Namespace|Service|Job|Ingress|Node$
       - include:
         - path: $.kind
           match: ^ConfigMap$

--- a/deploy/k8s-v1.20/chkk-cronjob.yaml
+++ b/deploy/k8s-v1.20/chkk-cronjob.yaml
@@ -4,7 +4,7 @@ metadata:
   name: chkk-system
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/name: chkk-cluster-context-cronjob
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
   namespace: chkk-system
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/name: chkk-cluster-context-cronjob
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
 rules:
   - apiGroups:
@@ -106,7 +106,7 @@ metadata:
     app.kubernetes.io/name: chkk-cluster-context-cronjob
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -126,7 +126,7 @@ data:
           match: ^DaemonSet|Deployment|Pod|PodTemplate|ReplicationController|StatefulSet$
       - include:
         - path: $.kind
-          match: ^NetworkPolicy|CronJob|Namespace|Service|Job|Ingress$
+          match: ^NetworkPolicy|CronJob|Namespace|Service|Job|Ingress|Node$
       - include:
         - path: $.kind
           match: ^ConfigMap$
@@ -140,7 +140,7 @@ metadata:
     app.kubernetes.io/name: chkk-cluster-context-cronjob
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
   namespace: chkk-system
 ---
@@ -153,7 +153,7 @@ metadata:
     app.kubernetes.io/name: chkk-cluster-context-cronjob
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
   namespace: chkk-system
 ---
@@ -167,7 +167,7 @@ metadata:
     chkk.io/name: chkk-cluster-agent
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
   namespace: chkk-system
 spec:
@@ -178,7 +178,7 @@ spec:
         app.kubernetes.io/name: chkk-cronjob
       annotations:
         chkk.io/name: Cluster Agent
-        chkk.io/version: v1.0.27
+        chkk.io/version: v1.0.28
     spec:
       template:
         metadata:
@@ -187,7 +187,7 @@ spec:
             app.kubernetes.io/name: chkk-cronjob
           annotations:
             chkk.io/name: Cluster Agent
-            chkk.io/version: v1.0.27
+            chkk.io/version: v1.0.28
         spec:
           automountServiceAccountToken: true
           containers:
@@ -201,7 +201,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: public.ecr.aws/j8z4q9j4/chkk-kontext:v1.0.27
+              image: public.ecr.aws/j8z4q9j4/chkk-kontext:v1.0.28
               imagePullPolicy: Always
               name: chkk-cluster-context-cronjob
               resources:
@@ -249,7 +249,7 @@ kind: Deployment
 metadata:
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   labels:
     app.kubernetes.io/instance: chkk-cluster-agent-manager
     app.kubernetes.io/managed-by: kubectl
@@ -265,7 +265,7 @@ spec:
     metadata:
       annotations:
         chkk.io/name: Cluster Agent
-        chkk.io/version: v1.0.27
+        chkk.io/version: v1.0.28
       labels:
         app.kubernetes.io/name: chkk-cluster-agent-manager
     spec:
@@ -277,7 +277,7 @@ spec:
                 secretKeyRef:
                   key: CHKK_ACCESS_TOKEN
                   name: chkk-access-token
-          image: public.ecr.aws/j8z4q9j4/chkk-cluster-agent-manager:v1.0.27
+          image: public.ecr.aws/j8z4q9j4/chkk-cluster-agent-manager:v1.0.28
           imagePullPolicy: Always
           name: chkk-cluster-agent-manager
           resources:

--- a/deploy/k8s-v1.21/chkk-cronjob.yaml
+++ b/deploy/k8s-v1.21/chkk-cronjob.yaml
@@ -4,7 +4,7 @@ metadata:
   name: chkk-system
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/name: chkk-cluster-context-cronjob
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
   namespace: chkk-system
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/name: chkk-cluster-context-cronjob
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
 rules:
   - apiGroups:
@@ -106,7 +106,7 @@ metadata:
     app.kubernetes.io/name: chkk-cluster-context-cronjob
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -126,7 +126,7 @@ data:
           match: ^DaemonSet|Deployment|Pod|PodTemplate|ReplicationController|StatefulSet$
       - include:
         - path: $.kind
-          match: ^NetworkPolicy|CronJob|Namespace|Service|Job|Ingress$
+          match: ^NetworkPolicy|CronJob|Namespace|Service|Job|Ingress|Node$
       - include:
         - path: $.kind
           match: ^ConfigMap$
@@ -140,7 +140,7 @@ metadata:
     app.kubernetes.io/name: chkk-cluster-context-cronjob
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
   namespace: chkk-system
 ---
@@ -153,7 +153,7 @@ metadata:
     app.kubernetes.io/name: chkk-cluster-context-cronjob
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
   namespace: chkk-system
 ---
@@ -167,7 +167,7 @@ metadata:
     chkk.io/name: chkk-cluster-agent
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   name: chkk-cluster-context-cronjob
   namespace: chkk-system
 spec:
@@ -178,7 +178,7 @@ spec:
         app.kubernetes.io/name: chkk-cronjob
       annotations:
         chkk.io/name: Cluster Agent
-        chkk.io/version: v1.0.27
+        chkk.io/version: v1.0.28
     spec:
       template:
         metadata:
@@ -187,7 +187,7 @@ spec:
             app.kubernetes.io/name: chkk-cronjob
           annotations:
             chkk.io/name: Cluster Agent
-            chkk.io/version: v1.0.27
+            chkk.io/version: v1.0.28
         spec:
           automountServiceAccountToken: true
           containers:
@@ -201,7 +201,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: public.ecr.aws/j8z4q9j4/chkk-kontext:v1.0.27
+              image: public.ecr.aws/j8z4q9j4/chkk-kontext:v1.0.28
               imagePullPolicy: Always
               name: chkk-cluster-context-cronjob
               resources:
@@ -249,7 +249,7 @@ kind: Deployment
 metadata:
   annotations:
     chkk.io/name: Cluster Agent
-    chkk.io/version: v1.0.27
+    chkk.io/version: v1.0.28
   labels:
     app.kubernetes.io/instance: chkk-cluster-agent-manager
     app.kubernetes.io/managed-by: kubectl
@@ -265,7 +265,7 @@ spec:
     metadata:
       annotations:
         chkk.io/name: Cluster Agent
-        chkk.io/version: v1.0.27
+        chkk.io/version: v1.0.28
       labels:
         app.kubernetes.io/name: chkk-cluster-agent-manager
     spec:
@@ -277,7 +277,7 @@ spec:
                 secretKeyRef:
                   key: CHKK_ACCESS_TOKEN
                   name: chkk-access-token
-          image: public.ecr.aws/j8z4q9j4/chkk-cluster-agent-manager:v1.0.27
+          image: public.ecr.aws/j8z4q9j4/chkk-cluster-agent-manager:v1.0.28
           imagePullPolicy: Always
           name: chkk-cluster-agent-manager
           resources:


### PR DESCRIPTION
## Description

- Updated image tag and labels to `v1.0.28`
- Added `Node` in Cluster Agent config